### PR TITLE
Debug evaluation step

### DIFF
--- a/decoding/utils_eval.py
+++ b/decoding/utils_eval.py
@@ -80,9 +80,9 @@ class WER(object):
         scores = []
         for ref_seg, pred_seg in zip(ref, pred):
             if len(ref_seg) == 0 : error = 1.0
-            else: error = wer(ref_seg, pred_seg)
+            else: error = wer(' '.join(ref_seg), ' '.join(pred_seg))
             if self.use_score: scores.append(1 - error)
-            else: use_score.append(error)
+            else: scores.append(error)
         return np.array(scores)
     
 """


### PR DESCRIPTION
Currently, running the last evaluation step in the readme returns an error which states WER expects the length of ref and pred lists to be the same. This is because currently, the lists being passed in are a list of single words which constitute a phrase. They should instead be a single string that contains the whole phrase. The edit in line 83 addresses this.

Also, line 85 seems to contain a typo.

Both changes have been tested and verified.